### PR TITLE
Localize関係の実装調査

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,0 +1,9 @@
+{
+  "@@locale": "en",
+  "@@last_modified": "2020-05-18T21:09:20.251351",
+  "appTitle": "Flutter Sampler",
+  "@appTitle": {
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,0 +1,9 @@
+{
+  "@@locale": "ja",
+  "@@last_modified": "2020-05-18T21:09:20.251351",
+  "appTitle": "ふらったぁ見本集",
+  "@appTitle": {
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,0 +1,9 @@
+{
+  "@@locale": "messages",
+  "@@last_modified": "2020-05-18T21:09:20.251351",
+  "appTitle": "FLUTTER SAMPLER",
+  "@appTitle": {
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -2,11 +2,21 @@ import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 
 import 'l10n_delegate.dart';
+import 'messages_all.dart';
 
 class L10n {
   static const LocalizationsDelegate<L10n> delegate = L10nDelegate();
 
   static Future<L10n> load(Locale locale) async {
+    final name = locale.countryCode == null || locale.countryCode.isEmpty
+        ? locale.languageCode
+        : locale.toString();
+    final localeName = Intl.canonicalizedLocale(name);
+
+    // messages_allがmessages_*.dartから言語リソースを読み込む
+    await initializeMessages(localeName);
+    Intl.defaultLocale = localeName;
+
     return L10n();
   }
 
@@ -14,8 +24,8 @@ class L10n {
     return Localizations.of(context, L10n);
   }
 
-  String get hello => Intl.message(
-        'こんにちは',
-        name: 'hello',
+  String get appTitle => Intl.message(
+        'FLUTTER SAMPLER',
+        name: 'appTitle',
       );
 }

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+
+import 'l10n_delegate.dart';
+
+class L10n {
+  static const LocalizationsDelegate<L10n> delegate = L10nDelegate();
+
+  static Future<L10n> load(Locale locale) async {
+    return L10n();
+  }
+
+  static L10n of(BuildContext context) {
+    return Localizations.of(context, L10n);
+  }
+
+  String get hello => Intl.message(
+        'こんにちは',
+        name: 'hello',
+      );
+}

--- a/lib/l10n/l10n_delegate.dart
+++ b/lib/l10n/l10n_delegate.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+
+import 'l10n.dart';
+
+class L10nDelegate extends LocalizationsDelegate<L10n> {
+  const L10nDelegate();
+
+  @override
+  bool isSupported(Locale locale) {
+    return false;
+  }
+
+  @override
+  Future<L10n> load(Locale locale) => L10n.load(locale);
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<L10n> old) {
+    return true;
+  }
+}

--- a/lib/l10n/l10n_delegate.dart
+++ b/lib/l10n/l10n_delegate.dart
@@ -6,9 +6,9 @@ class L10nDelegate extends LocalizationsDelegate<L10n> {
   const L10nDelegate();
 
   @override
-  bool isSupported(Locale locale) {
-    return false;
-  }
+  // isSupportedがfalseを返していると、Localizations.of(context, L10n)はnullになる
+  // localeについては、MaterialApp.supportedLocalesで適用されたもののみが渡ってきうる
+  bool isSupported(Locale locale) => ['ja', 'en'].contains(locale.languageCode);
 
   @override
   Future<L10n> load(Locale locale) => L10n.load(locale);

--- a/lib/l10n/messages_all.dart
+++ b/lib/l10n/messages_all.dart
@@ -1,0 +1,71 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that looks up messages for specific locales by
+// delegating to the appropriate library.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:implementation_imports, file_names, unnecessary_new
+// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
+// ignore_for_file:argument_type_not_assignable, invalid_assignment
+// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
+// ignore_for_file:comment_references
+
+import 'dart:async';
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+import 'package:intl/src/intl_helpers.dart';
+
+import 'messages_en.dart' deferred as messages_en;
+import 'messages_ja.dart' deferred as messages_ja;
+import 'messages_messages.dart' deferred as messages_messages;
+
+typedef Future<dynamic> LibraryLoader();
+Map<String, LibraryLoader> _deferredLibraries = {
+  'en': messages_en.loadLibrary,
+  'ja': messages_ja.loadLibrary,
+  'messages': messages_messages.loadLibrary,
+};
+
+MessageLookupByLibrary _findExact(String localeName) {
+  switch (localeName) {
+    case 'en':
+      return messages_en.messages;
+    case 'ja':
+      return messages_ja.messages;
+    case 'messages':
+      return messages_messages.messages;
+    default:
+      return null;
+  }
+}
+
+/// User programs should call this before using [localeName] for messages.
+Future<bool> initializeMessages(String localeName) async {
+  var availableLocale = Intl.verifiedLocale(
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
+  if (availableLocale == null) {
+    return new Future.value(false);
+  }
+  var lib = _deferredLibraries[availableLocale];
+  await (lib == null ? new Future.value(false) : lib());
+  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
+  return new Future.value(true);
+}
+
+bool _messagesExistFor(String locale) {
+  try {
+    return _findExact(locale) != null;
+  } catch (e) {
+    return false;
+  }
+}
+
+MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
+  if (actualLocale == null) return null;
+  return _findExact(actualLocale);
+}

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -1,0 +1,26 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'en';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "appTitle" : MessageLookupByLibrary.simpleMessage("Flutter Sampler")
+  };
+}

--- a/lib/l10n/messages_ja.dart
+++ b/lib/l10n/messages_ja.dart
@@ -1,0 +1,26 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a ja locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'ja';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "appTitle" : MessageLookupByLibrary.simpleMessage("ふらったぁ見本集")
+  };
+}

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -1,0 +1,26 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a messages locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'messages';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function>{
+        "appTitle": MessageLookupByLibrary.simpleMessage("FLUTTER SAMPLER")
+      };
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+import 'l10n/l10n.dart';
 
 void main() {
   runApp(MyApp());
@@ -15,6 +18,12 @@ class MyApp extends StatelessWidget {
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
       home: MyHomePage(),
+      localizationsDelegates: [
+        L10n.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,10 @@ class MyApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
+      supportedLocales: [
+        Locale('en'),
+        Locale('ja'),
+      ],
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,7 @@ class MyHomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Flutter Sampler'),
+        title: Text(L10n.of(context).appTitle),
       ),
       body: Container(),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,8 @@
 name: fluttersample
 description: A new Flutter application.
 
-# The following line prevents the package from being accidentally published to
-# pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
 
 environment:
@@ -23,54 +11,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,11 +11,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   cupertino_icons: ^0.1.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  intl_translation: any
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
close #1 

# やったこと
- Flutterでの多言語対応

# 登場人物
- `LocalizationsDelegate<T>`：これの継承クラスを`MaterialApp.localizationsDelegates` にセットすることで多言語対応が可能になる
- `L10n/AppLocalizations`：👆のTに相当。
  - 主な役割は以下の2つ。
    - 言語ごとの文言へアクセスする際のハブになる(例：`L10n.of(context).hoge`)
    - 多言語対応する文言のマスタを格納する。
- intl_**.arb
  - `L10n/AppLocalizations`から`flutter pub run intl_translation:extract_to_arb`で生成されるファイル郡。各言語ごとの文言を格納する。これらのファイル群を元にmessage_**.dartが生成されるので、最終的には不要になる？
- `message_**.dart`
  - 最終的な文言を格納するdartファイル群。
  - `message_all.dart`は他の`message_**.dart`を読み込み、Localeを元に分岐をかける
  - `message_**.dart`は**(例：`en | ja`)ごとの文言を格納する。

# 参考
- [Dart/Flutter での多言語対応あれこれ](https://medium.com/flutter-jp/intl-beb5b9e8ee73)
- [Flutter Localization with ARB made simple](https://medium.com/@angga.arifandi/flutter-localization-with-arb-made-simple-c03da609dcaf)
- [google / app-resource-bundle - GitHub](https://github.com/google/app-resource-bundle)