### PR TITLE
pedantic_monoを導入

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+# https://pub.dev/packages/pedantic_mono
+include: package:pedantic_mono/analysis_options.yaml

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,6 @@
 # https://pub.dev/packages/pedantic_mono
 include: package:pedantic_mono/analysis_options.yaml
+
+analyzer:
+  exclude:
+    - lib/l10n/messages_*.dart

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,13 +18,13 @@ class MyApp extends StatelessWidget {
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
       home: MyHomePage(),
-      localizationsDelegates: [
+      localizationsDelegates: const [
         L10n.delegate,
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: [
+      supportedLocales: const [
         Locale('en'),
         Locale('ja'),
       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   intl_translation: any
+  pedantic_mono: any
 
 flutter:
   uses-material-design: true
+


### PR DESCRIPTION
# やったこと
- [Dart/Flutter の静的解析強化のススメ](https://medium.com/flutter-jp/analysis-b8dbb19d3978)に従い、pedantic_monoを導入

# 備考
- `flutter analyze` では`No issues found!`となるが、Android Studioではexcludeが効いていない...
- dart-lang/sdk #25551 が関係あるかも...🤔