### PR TITLE
DartのNNDBを導入

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,3 +4,5 @@ include: package:pedantic_mono/analysis_options.yaml
 analyzer:
   exclude:
     - lib/l10n/messages_*.dart
+  enable-experiment:
+    - non-nullable

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -8,9 +8,9 @@ class L10n {
   static const LocalizationsDelegate<L10n> delegate = L10nDelegate();
 
   static Future<L10n> load(Locale locale) async {
-    final name = locale.countryCode == null || locale.countryCode.isEmpty
-        ? locale.languageCode
-        : locale.toString();
+    final countryCode = locale.countryCode ?? '';
+    final name = countryCode.isEmpty ? locale.languageCode : locale.toString();
+
     final localeName = Intl.canonicalizedLocale(name);
 
     // messages_allがmessages_*.dartから言語リソースを読み込む

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0-21.10.beta <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
resolve #9 

## やったこと
- [Flutter で Null Safety を有効にする](https://medium.com/@wasabeef/flutter-%E3%81%A7-null-safety-%E3%82%92%E6%9C%89%E5%8A%B9%E3%81%AB%E3%81%99%E3%82%8B-45f4171327a)を参考に、デフォルトでNullを許容しないように設定を変更
- 既存コードも一部変更